### PR TITLE
Add health check procedure for Push Gateways in documentation

### DIFF
--- a/docs/concept.adoc
+++ b/docs/concept.adoc
@@ -278,6 +278,18 @@ image::diagrams/registration_complex.svg[width=100%]
 
 Durch die extra Schritte ist es später möglich, einen eventuell neu vergebenen Push Token von z.B. Apple oder Google am internen Dienst neu zu hinterlegen. Es ist keine Aktualisierung der Registrierung am FD notwendig.
 
+=== Health Check der Push Gateways durch den Fachdienst
+Da das Push Gateway keinen Health-Check-Endpunkt bereitstellt, kann der Fachdienst selbst prüfen, ob das Push Gateway erreichbar ist. Der nachfolgend beschriebene Ablauf stellt eine mögliche Umsetzung dieses Checks dar.
+
+Beim Start des Dienstes, unabhängig davon, ob es sich um den Fachdienst selbst oder einen Exporter-Dienst handelt, ruft dieser alle im Dienst konfigurierten Push-Gateways jeweils mit einem GET /-Request auf.
+
+Dieser Health Check prüft,
+
+1. ob das jeweilige Push Gateway erreichbar ist und
+2. ob der TLS-Handshake inklusive mTLS erfolgreich durchläuft.
+
+Wenn der Fachdienst eine HTTP-Response erhält, gilt der Health Check als erfolgreich.
+
 == Beispiele
 
 === Device Registrierung

--- a/docs_sources/concept-source.adoc
+++ b/docs_sources/concept-source.adoc
@@ -245,6 +245,18 @@ image::diagrams/registration_complex.svg[width=100%]
 
 Durch die extra Schritte ist es später möglich, einen eventuell neu vergebenen Push Token von z.B. Apple oder Google am internen Dienst neu zu hinterlegen. Es ist keine Aktualisierung der Registrierung am FD notwendig.
 
+=== Health Check der Push Gateways durch den Fachdienst
+Da das Push Gateway keinen Health-Check-Endpunkt bereitstellt, kann der Fachdienst selbst prüfen, ob das Push Gateway erreichbar ist. Der nachfolgend beschriebene Ablauf stellt eine mögliche Umsetzung dieses Checks dar.
+
+Beim Start des Dienstes (sei es der Fachdienst selbst, oder ein Exporter-Dienst) ruft der Fachdienst alle konfigurierten Push Gateways jeweils mit einem `GET /`-Request auf.
+
+Dieser Health Check prüft,
+
+1. ob das jeweilige Push Gateway erreichbar ist und
+2. ob der TLS-Handshake inklusive mTLS erfolgreich durchläuft.
+
+Wenn der Fachdienst eine HTTP-Response erhält, gilt der Health Check als erfolgreich.
+
 == Beispiele
 
 === Device Registrierung

--- a/docs_sources/concept-source.adoc
+++ b/docs_sources/concept-source.adoc
@@ -248,7 +248,7 @@ Durch die extra Schritte ist es später möglich, einen eventuell neu vergebenen
 === Health Check der Push Gateways durch den Fachdienst
 Da das Push Gateway keinen Health-Check-Endpunkt bereitstellt, kann der Fachdienst selbst prüfen, ob das Push Gateway erreichbar ist. Der nachfolgend beschriebene Ablauf stellt eine mögliche Umsetzung dieses Checks dar.
 
-Beim Start des Dienstes (sei es der Fachdienst selbst, oder ein Exporter-Dienst) ruft der Fachdienst alle konfigurierten Push Gateways jeweils mit einem `GET /`-Request auf.
+Beim Start des Dienstes, unabhängig davon, ob es sich um den Fachdienst selbst oder einen Exporter-Dienst handelt, ruft dieser alle im Dienst konfigurierten Push-Gateways jeweils mit einem GET /-Request auf.
 
 Dieser Health Check prüft,
 


### PR DESCRIPTION
Document a health check procedure for Push Gateways, detailing how the service can verify their availability and successful TLS handshake.